### PR TITLE
Increasing buffer when copying will increase copy speed.

### DIFF
--- a/belvedere/src/main/java/com/zendesk/belvedere/BelvedereResolveUriTask.java
+++ b/belvedere/src/main/java/com/zendesk/belvedere/BelvedereResolveUriTask.java
@@ -63,7 +63,7 @@ class BelvedereResolveUriTask extends AsyncTask<Uri, Void, List<BelvedereResult>
 
                     fileOutputStream = new FileOutputStream(file);
 
-                    final byte[] buf = new byte[1024];
+                    final byte[] buf = new byte[1024 * 1024];
                     int len;
                     while ((len = inputStream.read(buf)) > 0) {
                         fileOutputStream.write(buf, 0, len);


### PR DESCRIPTION
Right now copying 27 Mb, previously average is 1500ms, now is 400ms

### Changes

### Reviewers
@brendan-fahy @baz8080 @schlan @eepDev

### FYI
@KevinLambe

### References
- None

### Risks
- None
