### PR TITLE
Upgrade to Picasso 2.71828

### DIFF
--- a/belvedere/build.gradle
+++ b/belvedere/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation group: 'com.android.support', name: 'appcompat-v7', version: rootProject.ext.supportLibVersion
     implementation group: 'com.android.support', name: 'cardview-v7', version: rootProject.ext.supportLibVersion
     implementation group: 'com.android.support', name: 'design', version: rootProject.ext.supportLibVersion
-    implementation group: 'com.squareup.picasso', name: 'picasso', version: '2.5.2'
+    implementation group: 'com.squareup.picasso', name: 'picasso', version: '2.71828'
 
     // Unit tests
     testImplementation group: 'junit', name: 'junit', version: '4.12'

--- a/belvedere/consumer-proguard.pro
+++ b/belvedere/consumer-proguard.pro
@@ -1,2 +1,6 @@
 # Picasso
 -dontwarn com.squareup.picasso.**
+
+# OkHttp3
+-dontwarn okhttp3.**
+-dontwarn okio.**

--- a/belvedere/src/main/java/zendesk/belvedere/FixedWidthImageView.java
+++ b/belvedere/src/main/java/zendesk/belvedere/FixedWidthImageView.java
@@ -185,7 +185,7 @@ public class FixedWidthImageView extends AppCompatImageView implements Target {
     }
 
     @Override
-    public void onBitmapFailed(Drawable errorDrawable) {
+    public void onBitmapFailed(Exception ex, Drawable errorDrawable) {
         // intentionally empty
     }
 

--- a/belvedere/src/main/java/zendesk/belvedere/ImageStreamItems.java
+++ b/belvedere/src/main/java/zendesk/belvedere/ImageStreamItems.java
@@ -173,9 +173,9 @@ class ImageStreamItems {
             container.setContentDescriptionStrings(unselect, select);
 
             if(dimensions != null) {
-                imageView.showImage(Picasso.with(context), mediaResult.getOriginalUri(), dimensions);
+                imageView.showImage(Picasso.get(), mediaResult.getOriginalUri(), dimensions);
             } else {
-                imageView.showImage(Picasso.with(context), mediaResult.getOriginalUri(), mediaResult.getWidth(), mediaResult.getHeight(), new FixedWidthImageView.DimensionsCallback() {
+                imageView.showImage(Picasso.get(), mediaResult.getOriginalUri(), mediaResult.getWidth(), mediaResult.getHeight(), new FixedWidthImageView.DimensionsCallback() {
                     @Override
                     public void onImageDimensionsFound(FixedWidthImageView.CalculatedDimensions dimensions) {
                         StreamItemImage.this.dimensions = dimensions;

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ ext {
     minSdkVersionUi = 16
 
     supportLibVersion = "27.1.0"
-    versionName = "2.2.0-SNAPSHOT"
+    versionName = "2.1.0-PCOMP"
 
     buildSettings = [
             localBuild : true,

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ ext {
     minSdkVersionCore = 16
     minSdkVersionUi = 16
 
-    supportLibVersion = "27.0.2"
+    supportLibVersion = "27.1.0"
     versionName = "2.2.0-SNAPSHOT"
 
     buildSettings = [
@@ -28,7 +28,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${rootProject.ext.kotlinVersion}"
     }
 }


### PR DESCRIPTION
### Changes
* Upgrade to Picasso 2.71828

### Reviewers
@brendan-fahy @baz8080 @schlan @eepDev @patrick-doyle 

### References
- [Picasso changelog](https://github.com/square/picasso/blob/master/CHANGELOG.md)

### Risks
- 2.71828 is a breaking change. Anyone using 2.5.2 who adds this version of Belvedere will have their project break because Belvedere will bring in 2.71828 and break their Picasso integration. We possibly shouldn't merge this to master, but likely want to provide a compatibility version of Belvedere that uses this version, for anyone who has upgraded to 2.71828
