### PR TITLE
Try PicassoCompat

### DIFF
--- a/belvedere-sample/build.gradle
+++ b/belvedere-sample/build.gradle
@@ -37,8 +37,7 @@ dependencies {
     implementation group: 'com.jakewharton', name: 'butterknife', version: '8.8.1'
     annotationProcessor group: 'com.jakewharton', name: 'butterknife-compiler', version: '8.8.1'
 
-    // noinspection GradleDependency: Breaking changes after Picasso 2.5.2 can cause crashes/compile errors in apps
-    implementation group: 'com.squareup.picasso', name: 'picasso', version: '2.5.2'
+    implementation group: 'com.squareup.picasso', name: 'picasso', version: '2.71828'
 
     if (useLocalDependency()) {
         api project(':belvedere')

--- a/belvedere/build.gradle
+++ b/belvedere/build.gradle
@@ -18,7 +18,6 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName rootProject.ext.versionName
-
         consumerProguardFiles 'consumer-proguard.pro'
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -35,13 +34,11 @@ dependencies {
     implementation group: 'com.android.support', name: 'appcompat-v7', version: rootProject.ext.supportLibVersion
     implementation group: 'com.android.support', name: 'cardview-v7', version: rootProject.ext.supportLibVersion
     implementation group: 'com.android.support', name: 'design', version: rootProject.ext.supportLibVersion
-
-    // noinspection GradleDependency: Breaking changes after Picasso 2.5.2 can cause crashes/compile errors in apps
-    implementation group: 'com.squareup.picasso', name: 'picasso', version: '2.5.2'
+    implementation group: 'com.sebchlan.picassocompat', name: 'picassocompat', version: '1.1.0'
 
     // Unit tests
     testImplementation group: 'junit', name: 'junit', version: '4.12'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '2.13.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '2.19.1'
     testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: rootProject.ext.kotlinVersion
-    testImplementation group: 'com.google.truth', name: 'truth', version: '0.36'
+    testImplementation group: 'com.google.truth', name: 'truth', version: '0.39'
 }

--- a/belvedere/src/main/java/zendesk/belvedere/FixedWidthImageView.java
+++ b/belvedere/src/main/java/zendesk/belvedere/FixedWidthImageView.java
@@ -10,8 +10,8 @@ import android.util.AttributeSet;
 import android.util.Pair;
 import android.widget.ImageView;
 
-import com.squareup.picasso.Picasso;
-import com.squareup.picasso.Target;
+import com.sebchlan.picassocompat.PicassoCompat;
+import com.sebchlan.picassocompat.TargetCompat;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -21,7 +21,7 @@ import zendesk.belvedere.ui.R;
  * For internal use only.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
-public class FixedWidthImageView extends AppCompatImageView implements Target {
+public class FixedWidthImageView extends AppCompatImageView implements TargetCompat {
 
     private static final String LOG_TAG = "FixedWidthImageView";
 
@@ -32,7 +32,7 @@ public class FixedWidthImageView extends AppCompatImageView implements Target {
     private int rawImageHeight;
 
     private Uri uri = null;
-    private Picasso picasso;
+    private PicassoCompat picasso;
 
     private final AtomicBoolean imageWaiting = new AtomicBoolean(false);
     private DimensionsCallback dimensionsCallback;
@@ -56,7 +56,7 @@ public class FixedWidthImageView extends AppCompatImageView implements Target {
         viewHeight = getResources().getDimensionPixelOffset(R.dimen.belvedere_image_stream_image_height);
     }
 
-    public void showImage(final Picasso picasso, final Uri uri, CalculatedDimensions dimensions) {
+    public void showImage(final PicassoCompat picasso, final Uri uri, CalculatedDimensions dimensions) {
 
         if(uri == null || uri.equals(this.uri)) {
             L.d(LOG_TAG, "Image already loaded. " + uri);
@@ -65,7 +65,7 @@ public class FixedWidthImageView extends AppCompatImageView implements Target {
 
         // cancel running picasso operations
         if(this.picasso != null) {
-            this.picasso.cancelRequest((Target) this);
+            this.picasso.cancelRequest((TargetCompat) this);
             this.picasso.cancelRequest((ImageView) this);
         }
 
@@ -79,7 +79,7 @@ public class FixedWidthImageView extends AppCompatImageView implements Target {
         startImageLoading(picasso, uri, viewWidth, rawImageWidth, rawImageHeight);
     }
 
-    public void showImage(final Picasso picasso, final Uri uri, long rawImageWidth, long rawImageHeight,
+    public void showImage(final PicassoCompat picasso, final Uri uri, long rawImageWidth, long rawImageHeight,
                           DimensionsCallback dimensionsCallback) {
 
         if(uri == null || uri.equals(this.uri)) {
@@ -89,7 +89,7 @@ public class FixedWidthImageView extends AppCompatImageView implements Target {
 
         // cancel running picasso operations
         if(this.picasso != null) {
-            this.picasso.cancelRequest((Target) this);
+            this.picasso.cancelRequest((TargetCompat) this);
             this.picasso.cancelRequest((ImageView) this);
         }
 
@@ -140,18 +140,18 @@ public class FixedWidthImageView extends AppCompatImageView implements Target {
         return Pair.create(width, (int)(imageHeight * scaleFactor));
     }
 
-    private void startImageLoading(Picasso picasso, Uri uri, int viewWidth, int rawImageWidth, int rawImageHeight) {
+    private void startImageLoading(PicassoCompat picasso, Uri uri, int viewWidth, int rawImageWidth, int rawImageHeight) {
         L.d(LOG_TAG, "Start loading image: " + viewWidth + " " + rawImageWidth + " " + rawImageHeight);
         if(rawImageWidth > 0 && rawImageHeight > 0) {
             final Pair<Integer, Integer> scaledDimensions =
                     scale(viewWidth, rawImageWidth, rawImageHeight);
             loadImage(picasso, scaledDimensions.first, scaledDimensions.second, uri);
         } else {
-            picasso.load(uri).into((Target) this);
+            picasso.load(uri).into((TargetCompat) this);
         }
     }
 
-    private void loadImage(Picasso picasso, int scaledImageWidth, int scaledImageHeight, Uri uri) {
+    private void loadImage(PicassoCompat picasso, int scaledImageWidth, int scaledImageHeight, Uri uri) {
         // the image height is known. update the view
         this.viewHeight = scaledImageHeight;
 
@@ -176,7 +176,7 @@ public class FixedWidthImageView extends AppCompatImageView implements Target {
     }
 
     @Override
-    public void onBitmapLoaded(Bitmap bitmap, Picasso.LoadedFrom from) {
+    public void onBitmapLoaded(Bitmap bitmap, PicassoCompat.LoadedFrom from) {
         this.rawImageHeight = bitmap.getHeight();
         this.rawImageWidth = bitmap.getWidth();
 

--- a/belvedere/src/main/java/zendesk/belvedere/ImageStreamItems.java
+++ b/belvedere/src/main/java/zendesk/belvedere/ImageStreamItems.java
@@ -8,7 +8,7 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.squareup.picasso.Picasso;
+import com.sebchlan.picassocompat.PicassoBridge;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -173,9 +173,9 @@ class ImageStreamItems {
             container.setContentDescriptionStrings(unselect, select);
 
             if(dimensions != null) {
-                imageView.showImage(Picasso.with(context), mediaResult.getOriginalUri(), dimensions);
+                imageView.showImage(PicassoBridge.init(context), mediaResult.getOriginalUri(), dimensions);
             } else {
-                imageView.showImage(Picasso.with(context), mediaResult.getOriginalUri(), mediaResult.getWidth(), mediaResult.getHeight(), new FixedWidthImageView.DimensionsCallback() {
+                imageView.showImage(PicassoBridge.init(context), mediaResult.getOriginalUri(), mediaResult.getWidth(), mediaResult.getHeight(), new FixedWidthImageView.DimensionsCallback() {
                     @Override
                     public void onImageDimensionsFound(FixedWidthImageView.CalculatedDimensions dimensions) {
                         StreamItemImage.this.dimensions = dimensions;

--- a/belvedere/src/main/java/zendesk/belvedere/Utils.java
+++ b/belvedere/src/main/java/zendesk/belvedere/Utils.java
@@ -17,7 +17,7 @@ import android.util.TypedValue;
 import android.view.View;
 import android.widget.ImageView;
 
-import com.squareup.picasso.Transformation;
+import com.sebchlan.picassocompat.TransformationCompat;
 
 import java.util.Locale;
 
@@ -82,12 +82,12 @@ class Utils {
         }
     }
 
-    static Transformation roundTransformation(Context context, int radiusResId) {
+    static TransformationCompat roundTransformation(Context context, int radiusResId) {
         final int radius = context.getResources().getDimensionPixelOffset(radiusResId);
         return new RoundedTransformation(radius, 0);
     }
 
-    private static class RoundedTransformation implements Transformation {
+    private static class RoundedTransformation implements TransformationCompat {
 
         private final int radius, margin;
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ apply from: 'scripts/gradle/zendesk-repos.gradle'
 apply from: 'scripts/gradle/zendesk-aggregate-javadocs.gradle'
 
 ext {
-    compileSdkVersion = 27
-    targetSdkVersion = 27
+    compileSdkVersion = 28
+    targetSdkVersion = 28
     minSdkVersionCore = 16
     minSdkVersionUi = 16
 
@@ -19,7 +19,7 @@ ext {
 buildscript {
 
     ext {
-        kotlinVersion = "1.2.51"
+        kotlinVersion = "1.2.71"
     }
 
     repositories {
@@ -28,7 +28,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${rootProject.ext.kotlinVersion}"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip


### PR DESCRIPTION
### Changes
PicassoCompat provides a thin compatibility later around the Picasso 2.5.2 and 2.7 APIs. By using it, the host app can either pull in Picasso 2.5.2 or 2.7. PicassoCompat detects the version of Picasso and forwards all calls to it. With this, it wouldn't be necessary to have a compatibility release. 

### Reviewers
@brendan-fahy @baz8080 @schlan @eepDev

### References
- https://github.com/schlan/picassocompat

### Risks
- A bit of reflection 
