### PR TITLE
Remove Use of Context#grantUriPermission() on Marshmallow and Above

### DIFF
--- a/belvedere-core/src/main/java/zendesk/belvedere/MediaSource.java
+++ b/belvedere-core/src/main/java/zendesk/belvedere/MediaSource.java
@@ -249,14 +249,14 @@ class MediaSource {
 
         final File imagePath = storage.getFileForCamera(context);
 
-        if(imagePath == null){
+        if (imagePath == null){
             L.w(Belvedere.LOG_TAG, "Camera Intent: Image path is null. There's something wrong with the storage.");
             return null;
         }
 
         final Uri uriForFile = storage.getFileProviderUri(context, imagePath);
 
-        if(uriForFile == null) {
+        if (uriForFile == null) {
             L.w(Belvedere.LOG_TAG, "Camera Intent: Uri to file is null. There's something wrong with the storage or FileProvider configuration.");
             return null;
         }

--- a/belvedere-core/src/main/java/zendesk/belvedere/Storage.java
+++ b/belvedere-core/src/main/java/zendesk/belvedere/Storage.java
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.MediaStore;
 import android.text.TextUtils;
 import android.util.Log;
@@ -49,12 +50,15 @@ class Storage {
      * @param permission Permission that should be granted to the Apps, opened by the provided Intent
      */
     void grantPermissionsForUri(Context context, Intent intent, Uri uri, int permission) {
-        List<ResolveInfo> resInfoList = context.getPackageManager().queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
-        for (ResolveInfo resolveInfo : resInfoList) {
-            String packageName = resolveInfo.activityInfo.packageName;
-            context.grantUriPermission(packageName, uri, permission);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            intent.addFlags(permission);
+        } else {
+            List<ResolveInfo> resInfoList = context.getPackageManager().queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+            for (ResolveInfo resolveInfo : resInfoList) {
+                String packageName = resolveInfo.activityInfo.packageName;
+                context.grantUriPermission(packageName, uri, permission);
+            }
         }
-        intent.addFlags(permission);
     }
 
     /**

--- a/belvedere-core/src/main/java/zendesk/belvedere/Storage.java
+++ b/belvedere-core/src/main/java/zendesk/belvedere/Storage.java
@@ -50,7 +50,7 @@ class Storage {
      * @param permission Permission that should be granted to the Apps, opened by the provided Intent
      */
     void grantPermissionsForUri(Context context, Intent intent, Uri uri, int permission) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             intent.addFlags(permission);
         } else {
             List<ResolveInfo> resInfoList = context.getPackageManager().queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);


### PR DESCRIPTION
### Changes
* Following on from #91, remove use of context#grantUriPermission() altogether as this was still causing crashes on some API versions

### Reviewers
@brendan-fahy @baz8080 @schlan @eepDev

### References
[Android Developer Docs for Context#grantUriPermission()](https://developer.android.com/reference/android/content/Context#grantUriPermission(java.lang.String,%20android.net.Uri,%20int))
```
Normally you should use Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION with the Intent being used to start an activity instead of this function directly.
```

### Risks
- None
