### PR TITLE
Add support to multiple content type filtering

### DIFF
--- a/belvedere-core/src/main/java/zendesk/belvedere/MediaIntent.java
+++ b/belvedere-core/src/main/java/zendesk/belvedere/MediaIntent.java
@@ -8,6 +8,9 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.util.Pair;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Model for representing a
  */
@@ -70,8 +73,6 @@ public class MediaIntent implements Parcelable {
      * Get the target of the intent.
      * <br />
      * Either {@link #TARGET_CAMERA} or {@link #TARGET_DOCUMENT}
-     *
-     * @return
      */
     public int getTarget() {
         return target;
@@ -87,12 +88,14 @@ public class MediaIntent implements Parcelable {
         private final int requestCode;
 
         String contentType;
+        List<String> additionalTypes;
         boolean allowMultiple;
 
         DocumentIntentBuilder(int requestCode, MediaSource mediaSource) {
             this.mediaSource = mediaSource;
             this.requestCode = requestCode;
             this.contentType = "*/*";
+            this.additionalTypes = new ArrayList<>();
             this.allowMultiple = false;
         }
 
@@ -100,14 +103,37 @@ public class MediaIntent implements Parcelable {
          * Create the {@link MediaIntent}
          */
         public MediaIntent build() {
-            return mediaSource.getGalleryIntent(requestCode, contentType, allowMultiple);
+            return mediaSource.getGalleryIntent(requestCode, contentType, allowMultiple, additionalTypes);
         }
 
         /**
-         * Restrict the selection to a content type
+         * Restrict the selection to a content type. Only one of the following should be called as
+         * they are mutually exclusive:
+         *
+         * <li>{@link DocumentIntentBuilder#contentType(String)}</li>
+         * <li>{@link DocumentIntentBuilder#contentTypes(List)}</li>
          */
         public DocumentIntentBuilder contentType(String contentType) {
             this.contentType = contentType;
+            this.additionalTypes = new ArrayList<>();
+            return this;
+        }
+
+        /**
+         * Restrict the selection to the specified content types. This can be used when allowing the
+         * selection of files from a disjoint set (e.g. "image&#47;*" and "text&#47;*"), in which
+         * case the content type is set to "*&#47;*".
+         * Only one of the following should be called as they are mutually exclusive:
+         *
+         * <li>{@link DocumentIntentBuilder#contentType(String)}</li>
+         * <li>{@link DocumentIntentBuilder#contentTypes(List)}</li>
+         *
+         * @param contentTypes the allowed content types
+         */
+        public DocumentIntentBuilder contentTypes(List<String> contentTypes) {
+            this.contentType = "*/*";
+            this.additionalTypes = new ArrayList<>();
+            this.additionalTypes.addAll(contentTypes);
             return this;
         }
 

--- a/belvedere-core/src/main/java/zendesk/belvedere/MediaSource.java
+++ b/belvedere-core/src/main/java/zendesk/belvedere/MediaSource.java
@@ -39,11 +39,19 @@ class MediaSource {
      * an installed gallery..
      *
      * @return An {@link MediaIntent} or null if this action isn't supported by
-     *      the system.
+     * the system.
      */
-    MediaIntent getGalleryIntent(int requestCode, String contentType, boolean allowMultiple){
-        if(hasDocumentApp(context)) {
-            return new MediaIntent(requestCode, getDocumentAndroidIntent(contentType, allowMultiple), null, true, MediaIntent.TARGET_DOCUMENT);
+    MediaIntent getGalleryIntent(int requestCode,
+                                 String contentType,
+                                 boolean allowMultiple,
+                                 List<String> additionalTypes) {
+        if (hasDocumentApp(context)) {
+            return new MediaIntent(
+                    requestCode,
+                    getDocumentAndroidIntent(contentType, allowMultiple, additionalTypes),
+                    null,
+                    true,
+                    MediaIntent.TARGET_DOCUMENT);
         }
         return MediaIntent.notAvailable();
     }
@@ -121,7 +129,7 @@ class MediaSource {
      * @return True if we have permissions to get a picture from a gallery, false if not allowed
      */
     private boolean hasDocumentApp(Context context){
-        return isIntentResolvable(getDocumentAndroidIntent("*/*", false), context);
+        return isIntentResolvable(getDocumentAndroidIntent("*/*", false, new ArrayList<String>()), context);
     }
 
     /**
@@ -296,10 +304,10 @@ class MediaSource {
      * @return An {@link MediaIntent}
      */
     @TargetApi(Build.VERSION_CODES.KITKAT)
-    private Intent getDocumentAndroidIntent(String contentType, boolean allowMultiple){
+    private Intent getDocumentAndroidIntent(String contentType, boolean allowMultiple, List<String> additionalTypes) {
         final Intent intent;
 
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             L.d(Belvedere.LOG_TAG, "Gallery Intent, using 'ACTION_OPEN_DOCUMENT'");
             intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
         } else {
@@ -310,9 +318,13 @@ class MediaSource {
         intent.setType(contentType);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
 
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2){
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             // if possible, allow the user to pick multiple images
             intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, allowMultiple);
+        }
+
+        if (additionalTypes != null && !additionalTypes.isEmpty()) {
+            intent.putExtra(Intent.EXTRA_MIME_TYPES, additionalTypes.toArray(new String[0]));
         }
 
         return intent;

--- a/belvedere/src/main/java/zendesk/belvedere/BelvedereUi.java
+++ b/belvedere/src/main/java/zendesk/belvedere/BelvedereUi.java
@@ -89,9 +89,13 @@ public class BelvedereUi {
         }
 
         /**
-         * Allow the user to select files from the system.
+         * Allow the user to select files of the specified content type from the system. Only one
+         * of the following should be called as they are mutually exclusive:
          *
-         * @param contentType restrict the files to a content type.
+         * <li>{@link ImageStreamBuilder#withDocumentIntent(String, boolean)}</li>
+         * <li>{@link ImageStreamBuilder#withDocumentIntent(List, boolean)}</li>
+         *
+         * @param contentType restrict the files to a content type
          * @param allowMultiple allow the user to select multiple attachments in a third party app or the system file picker
          */
         public ImageStreamBuilder withDocumentIntent(@NonNull String contentType, boolean allowMultiple) {
@@ -99,6 +103,27 @@ public class BelvedereUi {
                     .document()
                     .allowMultiple(allowMultiple)
                     .contentType(contentType)
+                    .build();
+            this.mediaIntents.add(mediaIntent);
+            return this;
+        }
+
+        /**
+         * Allow the user to select files of any specified content type from the system. This can
+         * be used when allowing the selection of files from a disjoint set (e.g. "image&#47;*" and
+         * "text&#47;*"). Only one of the following should be called as they are mutually exclusive:
+         *
+         * <li>{@link ImageStreamBuilder#withDocumentIntent(String, boolean)}</li>
+         * <li>{@link ImageStreamBuilder#withDocumentIntent(List, boolean)}</li>
+         *
+         * @param contentTypes restrict the files to the content types
+         * @param allowMultiple allow the user to select multiple attachments in a third party app or the system file picker
+         */
+        public ImageStreamBuilder withDocumentIntent(@NonNull List<String> contentTypes, boolean allowMultiple) {
+            final MediaIntent mediaIntent = Belvedere.from(context)
+                    .document()
+                    .allowMultiple(allowMultiple)
+                    .contentTypes(contentTypes)
                     .build();
             this.mediaIntents.add(mediaIntent);
             return this;


### PR DESCRIPTION
### Changes

* Add support for multiple content type filtering, useful when allowing the selection of files from disjoint sets (e.g. `image/*` and `text/*`)

### Reviewers
@brendan-fahy @baz8080 @schlan @eepDev

### References
- None

### Risks
- Low, it's a new API

### To test
1. Update `ChatActivity#showImageStream()` in the sample app to use the new API:
```
private void showImageStream() {
    List<String> acceptedTypes = new ArrayList<>();
    acceptedTypes.add("application/pdf");
    acceptedTypes.add("text/plain");

    BelvedereUi.imageStream(ChatActivity.this)
            .withCameraIntent()
            .withDocumentIntent(acceptedTypes, true)
            .withSelectedItems(new ArrayList<>(mediaResults))
            .withExtraItems(new ArrayList<>(extraResults))
            .withTouchableItems(R.id.attachment, R.id.send)
            .showPopup(ChatActivity.this);
}
```
2. Run the sample app and click the fab to open the document picker
3. Check that only documents of the specified types are visible

