### PR TITLE
Fix fab click listener behaviour

### DIFF
--- a/belvedere/src/main/java/zendesk/belvedere/FloatingActionMenu.java
+++ b/belvedere/src/main/java/zendesk/belvedere/FloatingActionMenu.java
@@ -76,6 +76,7 @@ public class FloatingActionMenu extends LinearLayout implements View.OnClickList
             setOrientation(LinearLayout.VERTICAL);
             setOnClickListener(this);
             fab = findViewById(R.id.floating_action_menu_fab);
+            fab.setOnClickListener(this);
             layoutInflater = LayoutInflater.from(context);
             menuItems = new ArrayList<>();
 


### PR DESCRIPTION
In some instances clicking directly on the fab won't invoke the parent class click listener. Delegating the listener to the parent class fixes this issue without UX changes.

### Changes
* Fix the nested fab click listener

### Reviewers
@brendan-fahy @baz8080 @schlan @eepDev

### References
- None

### Risks
- Low

### To test
1. Run the sample app
2. Click the fab to open the menu
3. Confirm that the fab continues to work as expected
