### PR TITLE
Removing the weak reference from the callback

### DIFF
--- a/belvedere-core/src/main/java/zendesk/belvedere/ResolveUriTask.java
+++ b/belvedere-core/src/main/java/zendesk/belvedere/ResolveUriTask.java
@@ -39,7 +39,7 @@ class ResolveUriTask extends AsyncTask<Uri, Void, List<MediaResult>> {
         resolveUriTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, uris);
     }
 
-    private final WeakReference<Callback<List<MediaResult>>> callback;
+    private Callback<List<MediaResult>> callback;
     private final Context context;
     private final Storage storage;
     private final String subDirectory;
@@ -49,7 +49,7 @@ class ResolveUriTask extends AsyncTask<Uri, Void, List<MediaResult>> {
         this.context = context;
         this.storage = storage;
         this.subDirectory = subDirectory;
-        this.callback = new WeakReference<>(callback);
+        this.callback = callback;
     }
 
     @Override
@@ -119,9 +119,10 @@ class ResolveUriTask extends AsyncTask<Uri, Void, List<MediaResult>> {
     @Override
     protected void onPostExecute(List<MediaResult> resolvedUris) {
         super.onPostExecute(resolvedUris);
-        final Callback<List<MediaResult>> callback = this.callback.get();
+
         if (callback != null) {
             callback.internalSuccess(resolvedUris);
+            callback = null;
         } else {
             L.w(Belvedere.LOG_TAG, "Callback null");
         }


### PR DESCRIPTION
### Changes
* Problem: sometimes if you try to get some images from gallery using the Belvedere singleton you will notice that the `getFilesFromActivityOnResult` callback  will not get called sometimes (a lot of times if you are using an older device). It happens because the `ResolveUriTask` store a `Callback<List<MediaResult>>` as a `WeakReference`. The problem is that `onPreExecute`, `onPostExecute` and `doInBackground` is run in different threads and there is also some delay when changing thread and the instance _may be_ cleared in between too which causes this bug. 

### Reviewers
@brendan-fahy @baz8080 @schlan @eepDev

### References
- None

### Risks
- I don't believe the changes I have made can cause a memory leak but to be honest I didn't have time to go throughout the whole code to verify it (I'm truly sorry for that), but one thing that I think can cause the memory leak is the `Context` object stored inside `ResolveUriTask` (I can observe this as soon as I get some time here).