### PR TITLE
Prevent memory leak of Callback in ImageStream, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ public class TestActivity extends AppCompatActivity {
 
     private ImageStream imageStream;
     private Button selectAttachment;
+    
+    // Make sure to manage a strong reference to the callback because Belvedere uses
+    // a WeakReference to avoid memory leaks
+    private Callback<List<MediaResult>> callback; 
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -107,12 +111,15 @@ public class TestActivity extends AppCompatActivity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        Belvedere.from(this).getFilesFromActivityOnResult(requestCode, resultCode, data, new Callback<List<MediaResult>>() {
+        
+        callback = new Callback<List<MediaResult>> () {
             @Override
             public void success(List<MediaResult> result) {
-                // Handle Selected files
+                // Handle selected files                
             }
-        });
+        };
+        
+        Belvedere.from(this).getFilesFromActivityOnResult(requestCode, resultCode, data, callback);
     }
 }
 ```
@@ -127,6 +134,10 @@ public class TestActivity extends AppCompatActivity {
     private ImageStream imageStream;
     private Button selectAttachmentFromCamera;
     private Button selectAttachmentFromDocuments;
+    
+    // Make sure to manage a strong reference to the callback because Belvedere uses
+    // a WeakReference to avoid memory leaks
+    private Callback<List<MediaResult>> callback; 
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -155,12 +166,15 @@ public class TestActivity extends AppCompatActivity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        Belvedere.from(this).getFilesFromActivityOnResult(requestCode, resultCode, data, new Callback<List<MediaResult>>() {
+        
+        callback = new Callback<List<MediaResult>> () {
             @Override
             public void success(List<MediaResult> result) {
-                // Handle Selected files
+                // Handle selected files                
             }
-        });
+        };
+        
+        Belvedere.from(this).getFilesFromActivityOnResult(requestCode, resultCode, data, callback);
     }
 }
 ```

--- a/belvedere-core/src/main/java/zendesk/belvedere/Belvedere.java
+++ b/belvedere-core/src/main/java/zendesk/belvedere/Belvedere.java
@@ -284,7 +284,7 @@ public class Belvedere {
         boolean debug;
 
         public Builder(Context context) {
-            this.context = context;
+            this.context = context.getApplicationContext();
             this.logger = new L.DefaultLogger();
             this.debug = false;
         }

--- a/belvedere-core/src/main/java/zendesk/belvedere/ResolveUriTask.java
+++ b/belvedere-core/src/main/java/zendesk/belvedere/ResolveUriTask.java
@@ -4,7 +4,6 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.os.Build;
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/belvedere/src/main/java/zendesk/belvedere/ImageStream.java
+++ b/belvedere/src/main/java/zendesk/belvedere/ImageStream.java
@@ -30,6 +30,8 @@ public class ImageStream extends Fragment {
 
     private PermissionManager permissionManager;
 
+    private Callback<List<MediaResult>> callback;
+
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -59,7 +61,8 @@ public class ImageStream extends Fragment {
     @Override
     public void onActivityResult(int requestCode, final int resultCode, final Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        Belvedere.from(this.getContext()).getFilesFromActivityOnResult(requestCode, resultCode, data, new Callback<List<MediaResult>>() {
+
+        callback = new Callback<List<MediaResult>>() {
             @Override
             public void success(List<MediaResult> result) {
                 List<MediaResult> filteredMediaResult = new ArrayList<>(result.size());
@@ -74,8 +77,12 @@ public class ImageStream extends Fragment {
                 }
 
                 notifyImageSelected(filteredMediaResult);
+
+                cancel();
             }
-        }, false);
+        };
+
+        Belvedere.from(this.getContext()).getFilesFromActivityOnResult(requestCode, resultCode, data, callback, false);
     }
 
     void setKeyboardHelper(KeyboardHelper keyboardHelper) {
@@ -117,6 +124,8 @@ public class ImageStream extends Fragment {
     }
 
     void notifyDismissed() {
+        callback = null; // Prevent memory leak of Callback
+
         for(WeakReference<Listener> ref : imageStreamListener) {
             final Listener listener = ref.get();
             if(listener != null) {

--- a/belvedere/src/main/java/zendesk/belvedere/ImageStream.java
+++ b/belvedere/src/main/java/zendesk/belvedere/ImageStream.java
@@ -77,8 +77,6 @@ public class ImageStream extends Fragment {
                 }
 
                 notifyImageSelected(filteredMediaResult);
-
-                cancel();
             }
         };
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ ext {
     minSdkVersionUi = 16
 
     supportLibVersion = "28.0.0"
-    versionName = "2.4.0-SNAPSHOT"
+    versionName = "2.4.1-SNAPSHOT"
 
     buildSettings = [
             localBuild : true,

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ ext {
     minSdkVersionUi = 16
 
     supportLibVersion = "28.0.0"
-    versionName = "2.4.1-SNAPSHOT"
+    versionName = "2.4.0-SNAPSHOT"
 
     buildSettings = [
             localBuild : true,


### PR DESCRIPTION
## Description
The Callback class's Javadoc says that direct references to it should be managed by clients, because ResolveUriTask uses a WeakReference for its Callback.

Unfortunately, our README didn't accurately reflect this important part of its usage (the code snippets showed anonymous inner Callback classes), and our ImageStream implementation also was not handling it properly.

### Changes
* Update code snippets in README to show intended usage.
* Update ImageStream to keep a strong reference to Callback. 
* Bump patch version (considering this code change to be a fix of broken/unintended behaviour). 

### Reviewers
@zendesk/adventure-android @zendesk/two-brothers-android @zendesk/ogham-android 

### FYI
@schlan 

### References
- #89 

### Risks
- Very low, as far as I can tell. I did some checking with LeakCanary to ensure I wasn't getting a memory leak on ImageStream with this implementation. 
