### PR TITLE
Commit ImageStream Fragment immediately

### DIFF
--- a/belvedere/src/main/java/zendesk/belvedere/BelvedereUi.java
+++ b/belvedere/src/main/java/zendesk/belvedere/BelvedereUi.java
@@ -57,7 +57,7 @@ public class BelvedereUi {
             supportFragmentManager
                     .beginTransaction()
                     .add(popupBackend, FRAGMENT_TAG_POPUP)
-                    .commit();
+                    .commitNow();
         }
 
         popupBackend.setKeyboardHelper(KeyboardHelper.inject(activity));


### PR DESCRIPTION
### Changes
* Commit ImageStream Fragment immediately using `commitNow` rather than `commit`. `commit` is performed asynchronously, while `commitNow` is synchronous. I am concerned that the asynchronous behaviour is interfering with some Espresso tests which utilise Belvedere in our product. I'd like to ship a new snapshot build with this change and see if it has any effect. If we find the behaviour change to be undesirable, we can revert this. 

### Reviewers
@zendesk/adventure-android @zendesk/two-brothers-android @zendesk/ogham-android 

### FYI
@schlan, my favourite reviewer

### References
- [FragmentTransaction docs](https://developer.android.com/reference/android/support/v4/app/FragmentTransaction.html#commitNow())

### Risks
- There are potential unexpected consequences for clients who expect the FragmentTransaction to be asynchronous rather than synchronous. 
