### PR TITLE
Attempt to build using API 30 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,8 @@ cache:
 android:
   components:
   - tools
-  - android-29
+  - android-30
   - platform-tools
-  - build-tools-29.0.2
   - extra-android-m2repository
   licenses:
   - android-sdk-license-[0-9a-f]{8}


### PR DESCRIPTION
### Changes
Attempt to build using API 30 on Travis.
There's a build failure on master about `android.useAndroidX` not existing, although it does. One hypothesis is that it's to do with the travis build being on API 29 rather than 30.

### Reviewers
@baz8080 @schlan @e2po @bridgeri127 @fibelatti

### References
- None

### Risks
- It's always tricky using newer build component version on travis.
