### PR TITLE
Fixes android.useAndroidX not being visible to isolated module builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,10 +36,10 @@ testBelvedere() {
 uploadSnapshotSdk() {
     export LOCAL_BUILD="false"
 
-    ./gradlew --settings-file scripts/gradle/build-belvedere-core.gradle clean :belvedere-core:uploadArchive
+    ./gradlew --settings-file scripts/gradle/build-belvedere-core.gradle -Pandroid.useAndroidX=true clean :belvedere-core:uploadArchive
     exitOnFailedBuild
 
-    ./gradlew --settings-file scripts/gradle/build-belvedere.gradle clean :belvedere:uploadArchive
+    ./gradlew --settings-file scripts/gradle/build-belvedere.gradle -Pandroid.useAndroidX=true clean :belvedere:uploadArchive
     exitOnFailedBuild
 
     buildSampleApp


### PR DESCRIPTION
### Changes

When building in isolation, the root project's gradle.properties file is not being read. This commit adds the android.useAndroidX property with a true value to the two places where we're doing isolated module builds. This approach was taken because it impacted one file, rather than the alternative of adding module level gradle.properties to the affected modules.

### Reviewers
@baz8080 @schlan @e2po @bridgeri127 @fibelatti

### References
- None

### Risks
- None
