### PR TITLE
Fixes release builds

### DIFF
--- a/scripts/gradle/zendesk-deploy.gradle
+++ b/scripts/gradle/zendesk-deploy.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'maven'
-apply plugin: 'signing'
 apply from: '../scripts/gradle/gradle-commons.gradle'
 
 ext {
@@ -22,7 +21,6 @@ afterEvaluate { project ->
     uploadArchives {
         repositories {
             mavenDeployer {
-                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
                 snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots") {
                     authentication(userName: repoUsername, password: repoPassword)
@@ -63,11 +61,6 @@ afterEvaluate { project ->
                 }
             }
         }
-    }
-
-    signing {
-        required { isReleaseBuild() }
-        sign configurations.archives
     }
 
     task androidJavadocs(type: Javadoc) {


### PR DESCRIPTION
### Changes
Previously, Belvedere's POMs were signed when building locally, but typically skipped when built on CI. This behaviour has changed with tooling updates, so this PR removes signing, until we can add it back by updating the CI environment.

### Reviewers
@baz8080 @schlan @e2po @bridgeri127 @fibelatti

### References
- None

### Risks
- None
