### PR TITLE
Create BelvederePermissionCallback For Runtime Premissions

### DIFF
--- a/belvedere-sample/src/main/java/com/example/belvedere/ChatActivity.java
+++ b/belvedere-sample/src/main/java/com/example/belvedere/ChatActivity.java
@@ -1,26 +1,34 @@
 package com.example.belvedere;
 
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.animation.Interpolator;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.view.animation.PathInterpolatorCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.material.snackbar.Snackbar;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 
+import zendesk.belvedere.BelvederePermissionCallback;
 import zendesk.belvedere.BelvedereUi;
 import zendesk.belvedere.ImageStream;
+import zendesk.belvedere.MediaIntent;
 import zendesk.belvedere.MediaResult;
 
 public class ChatActivity extends AppCompatActivity {
@@ -50,12 +58,12 @@ public class ChatActivity extends AppCompatActivity {
         findViewById(R.id.send).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if(imageStream.isAttachmentsPopupVisible()){
+                if (imageStream.isAttachmentsPopupVisible()) {
                     imageStream.dismiss();
                 }
                 mediaResults.clear();
                 extraResults.clear();
-                ((EditText)findViewById(R.id.input)).setText("");
+                ((EditText) findViewById(R.id.input)).setText("");
             }
         });
 
@@ -66,11 +74,11 @@ public class ChatActivity extends AppCompatActivity {
     }
 
     private void init() {
-        if(imageStream.getKeyboardHelper().getInputTrap().hasFocus()) {
+        if (imageStream.getKeyboardHelper().getInputTrap().hasFocus()) {
             input.requestFocus();
         }
 
-        if(imageStream.wasOpen()) {
+        if (imageStream.wasOpen()) {
             input.post(new Runnable() {
                 @Override
                 public void run() {
@@ -82,7 +90,7 @@ public class ChatActivity extends AppCompatActivity {
         findViewById(R.id.attachment).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if(!imageStream.isAttachmentsPopupVisible()) {
+                if (!imageStream.isAttachmentsPopupVisible()) {
                     showImageStream();
                 } else {
                     imageStream.dismiss();
@@ -117,7 +125,7 @@ public class ChatActivity extends AppCompatActivity {
         }
 
         private void refreshUi() {
-            if(!imageStream.isAttachmentsPopupVisible()) {
+            if (!imageStream.isAttachmentsPopupVisible()) {
                 showImageStream();
             }
         }
@@ -127,7 +135,7 @@ public class ChatActivity extends AppCompatActivity {
 
         @Override
         public void onScroll(int height, int scrollArea, float scrollPosition) {
-            final Interpolator interpolator = PathInterpolatorCompat.create(.19f,0f,.2f,1f);
+            final Interpolator interpolator = PathInterpolatorCompat.create(.19f, 0f, .2f, 1f);
             final float interpolation = interpolator.getInterpolation((scrollPosition * .30f));
             final int bottomPadding = (int) (-1f * interpolation * scrollArea);
             findViewById(R.id.activity_input).setTranslationY(bottomPadding);
@@ -142,6 +150,35 @@ public class ChatActivity extends AppCompatActivity {
                 .withSelectedItems(new ArrayList<>(mediaResults))
                 .withExtraItems(new ArrayList<>(extraResults))
                 .withTouchableItems(R.id.attachment, R.id.send)
+                .withBelvederePermissionCallback(new BelvederePermissionCallback() {
+                    @Override
+                    public void onPermissionsGranted(List<MediaIntent> mediaIntents) {
+
+                    }
+
+                    @Override
+                    public void onPermissionsDenied(boolean isMoreThanOnce) {
+                        if (isMoreThanOnce) {
+                            Snackbar snackbar = Snackbar
+                                    .make(findViewById(android.R.id.content),
+                                            "To send attachments, you must grant permissions in your settings",
+                                            Snackbar.LENGTH_LONG);
+                            snackbar.setAction("Settings", new OnClickListener() {
+                                @Override
+                                public void onClick(View v) {
+                                    Intent intent = new Intent();
+                                    intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                                    intent.setData(Uri.fromParts("package", ChatActivity.this.getPackageName(), null));
+                                    ChatActivity.this.startActivity(intent);
+                                }
+                            });
+                            snackbar.show();
+                        } else {
+                            Toast.makeText(ChatActivity.this, R.string.belvedere_permissions_denied, Toast.LENGTH_SHORT)
+                                    .show();
+                        }
+                    }
+                })
                 .showPopup(ChatActivity.this);
     }
 
@@ -151,12 +188,13 @@ public class ChatActivity extends AppCompatActivity {
         public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
             View v = LayoutInflater.from(parent.getContext())
                     .inflate(android.R.layout.simple_list_item_1, parent, false);
-            return new RecyclerView.ViewHolder(v) {};
+            return new RecyclerView.ViewHolder(v) {
+            };
         }
 
         @Override
         public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
-            ((TextView)holder.itemView.findViewById(android.R.id.text1)).setText("Belvedere Demo");
+            ((TextView) holder.itemView.findViewById(android.R.id.text1)).setText("Belvedere Demo");
         }
 
         @Override
@@ -164,4 +202,5 @@ public class ChatActivity extends AppCompatActivity {
             return 1;
         }
     }
+
 }

--- a/belvedere/src/main/java/zendesk/belvedere/BelvederePermissionCallback.java
+++ b/belvedere/src/main/java/zendesk/belvedere/BelvederePermissionCallback.java
@@ -1,0 +1,32 @@
+package zendesk.belvedere;
+
+import java.util.List;
+
+/**
+ * Permission Callback used to trigger the granted and denied runtime permissions.
+ *
+ * <p>
+ * This interface can be helpful for integrators if they want to build a custom logic that depends on the granted
+ * and denied runtime permissions.
+ * Like, building a SnackBar or a Dialog to let the user navigate to application settings in case of the user denied
+ * the runtime permissions more than once.
+ * </p>
+ */
+public interface BelvederePermissionCallback {
+
+    /**
+     * Callback that will be fired once the user granted the runtime permissions.
+     *
+     * @param mediaIntents They are the {@link MediaIntent} that the user granted.
+     */
+    void onPermissionsGranted(List<MediaIntent> mediaIntents);
+
+    /**
+     * Callback that will be fired once the user denied the runtime permissions.
+     *
+     * @param isMoreThanOnce It is a boolean value that will be true if the user denied the runtime permission only
+     *                       once, otherwise false.
+     */
+    void onPermissionsDenied(boolean isMoreThanOnce);
+
+}

--- a/belvedere/src/main/java/zendesk/belvedere/PermissionManager.java
+++ b/belvedere/src/main/java/zendesk/belvedere/PermissionManager.java
@@ -18,23 +18,24 @@ class PermissionManager {
 
     private static final int PERMISSION_REQUEST_CODE = 9842;
 
-    private PermissionStorage preferences;
+    private final PermissionStorage preferences;
     private InternalPermissionCallback permissionListener = null;
 
     PermissionManager(Context context) {
         this.preferences = new PermissionStorage(context);
     }
 
-    boolean onRequestPermissionsResult(Fragment fragment, int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    boolean onRequestPermissionsResult(Fragment fragment, int requestCode, @NonNull String[] permissions,
+            @NonNull int[] grantResults) {
         if (requestCode == PERMISSION_REQUEST_CODE) {
             final Map<String, Boolean> permissionResult = new HashMap<>();
             final List<String> dontAskAgain = new ArrayList<>();
 
-            for(int i = 0, c = permissions.length; i < c; i++) {
-                if(grantResults[i] == PackageManager.PERMISSION_GRANTED){
+            for (int i = 0, c = permissions.length; i < c; i++) {
+                if (grantResults[i] == PackageManager.PERMISSION_GRANTED) {
                     permissionResult.put(permissions[i], true);
 
-                } else if(grantResults[i] == PackageManager.PERMISSION_DENIED) {
+                } else if (grantResults[i] == PackageManager.PERMISSION_DENIED) {
                     permissionResult.put(permissions[i], false);
 
                     boolean showRationale = fragment.shouldShowRequestPermissionRationale(permissions[i]);
@@ -44,7 +45,7 @@ class PermissionManager {
                 }
             }
 
-            if(permissionListener != null) {
+            if (permissionListener != null) {
                 permissionListener.result(permissionResult, dontAskAgain);
             }
 
@@ -54,18 +55,19 @@ class PermissionManager {
         }
     }
 
-    void handlePermissions(final Fragment fragment, final List<MediaIntent> mediaIntents, final PermissionCallback permissionCallback) {
+    void handlePermissions(final Fragment fragment, final List<MediaIntent> mediaIntents,
+            final PermissionCallback permissionCallback) {
 
         final Context context = fragment.getContext();
         final List<String> permissions = new ArrayList<>();
         permissions.addAll(getPermissionsForImageStream(context));
         permissions.addAll(getPermissionsFromIntents(mediaIntents));
 
-        if(canShowImageStream(context) && permissions.isEmpty()) {
+        if (canShowImageStream(context) && permissions.isEmpty()) {
             permissionCallback.onPermissionsGranted(filterMediaIntents(context, mediaIntents));
 
-        } else if(!canShowImageStream(context) && permissions.isEmpty()){
-            permissionCallback.onPermissionsDenied();
+        } else if (!canShowImageStream(context) && permissions.isEmpty()) {
+            permissionCallback.onPermissionsDenied(true);
 
         } else {
             askForPermissions(fragment, permissions, new InternalPermissionCallback() {
@@ -73,21 +75,22 @@ class PermissionManager {
                 public void result(Map<String, Boolean> permissionResult, List<String> dontAskAgain) {
                     final List<MediaIntent> filteredMediaIntents = filterMediaIntents(context, mediaIntents);
 
-                    if(canShowImageStream(context)) {
+                    if (canShowImageStream(context)) {
                         permissionCallback.onPermissionsGranted(filteredMediaIntents);
                     } else {
-                        permissionCallback.onPermissionsDenied();
+                        permissionCallback.onPermissionsDenied(false);
                     }
                 }
             });
         }
     }
 
-    private void askForPermissions(Fragment fragment, final List<String> permissions, final InternalPermissionCallback permissionCallback) {
+    private void askForPermissions(Fragment fragment, final List<String> permissions,
+            final InternalPermissionCallback permissionCallback) {
         setListener(new InternalPermissionCallback() {
             @Override
             public void result(Map<String, Boolean> permissionResult, List<String> dontAskAgain) {
-                for(String permission : dontAskAgain) {
+                for (String permission : dontAskAgain) {
                     preferences.neverEverAskForThatPermissionAgain(permission);
                 }
                 permissionCallback.result(permissionResult, dontAskAgain);
@@ -102,12 +105,12 @@ class PermissionManager {
     private List<MediaIntent> filterMediaIntents(Context context, List<MediaIntent> intents) {
         final List<MediaIntent> filteredMediaIntents = new ArrayList<>();
 
-        for(MediaIntent mediaIntent : intents) {
-            if(mediaIntent.isAvailable()) {
-                if(TextUtils.isEmpty(mediaIntent.getPermission())) {
+        for (MediaIntent mediaIntent : intents) {
+            if (mediaIntent.isAvailable()) {
+                if (TextUtils.isEmpty(mediaIntent.getPermission())) {
                     filteredMediaIntents.add(mediaIntent);
                 } else {
-                    if(isPermissionGranted(context, mediaIntent.getPermission())) {
+                    if (isPermissionGranted(context, mediaIntent.getPermission())) {
                         filteredMediaIntents.add(mediaIntent);
                     }
                 }
@@ -122,7 +125,8 @@ class PermissionManager {
 
         for (MediaIntent intent : mediaIntents) {
             if (!TextUtils.isEmpty(intent.getPermission()) &&
-                    !preferences.shouldINeverEverAskForThatPermissionAgain(intent.getPermission()) && intent.isAvailable()) {
+                    !preferences.shouldINeverEverAskForThatPermissionAgain(intent.getPermission()) && intent
+                    .isAvailable()) {
                 permission.add(intent.getPermission());
             }
         }
@@ -137,7 +141,7 @@ class PermissionManager {
         final boolean canAskForStoragePermission =
                 !preferences.shouldINeverEverAskForThatPermissionAgain(Manifest.permission.READ_EXTERNAL_STORAGE);
 
-        if(!canShowImageStream && canAskForStoragePermission) {
+        if (!canShowImageStream && canAskForStoragePermission) {
             permissions.add(Manifest.permission.READ_EXTERNAL_STORAGE);
         }
 
@@ -160,11 +164,14 @@ class PermissionManager {
     }
 
     interface PermissionCallback {
+
         void onPermissionsGranted(List<MediaIntent> mediaIntents);
-        void onPermissionsDenied();
+
+        void onPermissionsDenied(boolean isMoreThanOnce);
     }
 
     private interface InternalPermissionCallback {
+
         void result(Map<String, Boolean> permissionResult, List<String> dontAskAgain);
     }
 


### PR DESCRIPTION
Create a `BelvederePermissionCallback` interface to let the integrators trigger the granted and denied runtime permissions if they want to create a custom logic that depends on that.

### Changes
* Create a `BelvederePermissionCallback` interface to let the integrators trigger the granted and denied runtime permissions if they want to create a custom logic that depends on that.
* Add a new function with the name `withBelvederePermissionCallback` in the `BelvedereUi` to let the integrators implement the `BelvederePermissionCallback` interface.
* Implement the new function in the `belvedere-sample` app to test the logic and let the integrators know how they can use the new API.

### Reviewers
@patrick-doyle  @e2po @ConorOD @ReguloSar 

### References
- None

### Risks
- None
