### PR TITLE
fix #135 IllegalStateException is not handled in ResolveUriTask.java

### DIFF
--- a/belvedere-core/src/main/java/zendesk/belvedere/ResolveUriTask.java
+++ b/belvedere-core/src/main/java/zendesk/belvedere/ResolveUriTask.java
@@ -94,6 +94,9 @@ class ResolveUriTask extends AsyncTask<Uri, Void, List<MediaResult>> {
             } catch (IOException e) {
                 L.e(Belvedere.LOG_TAG, String.format(Locale.US, "IO Error copying file, uri: %s", uri), e);
 
+            } catch (IllegalStateException e) {
+                L.e(Belvedere.LOG_TAG, String.format(Locale.US, "The file is either partially downloaded or corrupted, uri: %s", uri), e);
+
             } finally {
                 try {
                     if (inputStream != null) {


### PR DESCRIPTION
### Changes
IllegalStateException will cause crash if not handled

### Reviewers
@baz8080 @schlan @e2po @bridgeri127 @fibelatti

### References
- None

### Risks
- None
