### PR TITLE
[MFD-6389] Migrate Belvedere to Android 13

### DIFF
--- a/belvedere-core/src/main/java/zendesk/belvedere/PermissionUtil.java
+++ b/belvedere-core/src/main/java/zendesk/belvedere/PermissionUtil.java
@@ -23,6 +23,23 @@ class PermissionUtil {
     }
 
     /**
+     * Check if the user has granted a collection of permissions.
+     * @param context A valid application {@link Context}
+     * @param permissions list of permission to be checked
+     * @return true if all permissions were granted, otherwise false.
+     */
+    static boolean isPermissionGranted(Context context, String... permissions) {
+        if (context != null && permissions != null) {
+            for (String permission : permissions) {
+                if (ContextCompat.checkSelfPermission(context, permission) != PackageManager.PERMISSION_GRANTED) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
      * Internal helper method for checking, if a permission is declared in the
      * glorious {@code AndroidManifest.xml}.
      *

--- a/belvedere-sample/src/main/AndroidManifest.xml
+++ b/belvedere-sample/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
         android:theme="@style/AppTheme"
         android:name=".Global">
 
-        <activity android:name=".ChatActivity">
+        <activity android:name=".ChatActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/belvedere/src/main/AndroidManifest.xml
+++ b/belvedere/src/main/AndroidManifest.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="zendesk.belvedere.ui">
-    <!-- Required for granular permissions in Android 13. -->
+    <!-- Required only if your app targets Android 13. -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+
+    <!-- Required to maintain app compatibility. -->
     <uses-permission
         android:maxSdkVersion="32"
         android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/belvedere/src/main/AndroidManifest.xml
+++ b/belvedere/src/main/AndroidManifest.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="zendesk.belvedere.ui">
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <!-- Required for granular permissions in Android 13. -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission
+        android:maxSdkVersion="32"
+        android:name="android.permission.READ_EXTERNAL_STORAGE" />
 </manifest>

--- a/belvedere/src/main/java/zendesk/belvedere/BelvedereUi.java
+++ b/belvedere/src/main/java/zendesk/belvedere/BelvedereUi.java
@@ -16,6 +16,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -31,7 +32,8 @@ public class BelvedereUi {
     private final static String FRAGMENT_TAG = "BelvedereDialog";
     private final static String EXTRA_MEDIA_INTENT = "extra_intent";
     private final static String FRAGMENT_TAG_POPUP = "belvedere_image_stream";
-    private final static String INTENT_URI_SCHEMA = "package";
+    public final static String INTENT_URI_SCHEMA = "package";
+    public final static Long FIVE_SECONDS_DELAY = 5000L;
 
     /**
      * Gets the builder for showing the ImageStream.
@@ -218,21 +220,12 @@ public class BelvedereUi {
                         Utils.showBottomSheetDialog(
                                 parentView,
                                 appCompatActivity.getString(R.string.belvedere_permissions_rationale),
-                                5000L,
+                                FIVE_SECONDS_DELAY,
                                 appCompatActivity.getString(R.string.belvedere_navigate_to_settings),
                                 new OnClickListener() {
                                     @Override
                                     public void onClick(View v) {
-                                        Intent settingsIntent = new Intent();
-                                        settingsIntent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-                                        settingsIntent.setData(
-                                                Uri.fromParts(
-                                                        INTENT_URI_SCHEMA,
-                                                        appCompatActivity.getPackageName(),
-                                                        null
-                                                )
-                                        );
-                                        appCompatActivity.startActivity(settingsIntent);
+                                        Utils.openAppSettingsScreen(new WeakReference<>(appCompatActivity));
                                     }
                                 });
                     }

--- a/belvedere/src/main/java/zendesk/belvedere/ImageStream.java
+++ b/belvedere/src/main/java/zendesk/belvedere/ImageStream.java
@@ -13,6 +13,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
+import zendesk.belvedere.PermissionManager.InternalPermissionCallback;
 import zendesk.belvedere.ui.R;
 
 /**
@@ -154,6 +155,15 @@ public class ImageStream extends Fragment {
 
     void handlePermissions(final List<MediaIntent> mediaIntents, final PermissionManager.PermissionCallback permissionCallback) {
         permissionManager.handlePermissions(this, mediaIntents, permissionCallback);
+    }
+
+    /**
+     * Requests permissions from the given list.
+     * @param permissions list of permissions to be requested.
+     * @param permissionCallback callback that Keeps track of permissions' states
+     */
+    void requestPermissions(final List<String> permissions, final InternalPermissionCallback permissionCallback){
+        permissionManager.askForPermissions(this, permissions, permissionCallback);
     }
 
     /**

--- a/belvedere/src/main/java/zendesk/belvedere/ImageStreamPresenter.java
+++ b/belvedere/src/main/java/zendesk/belvedere/ImageStreamPresenter.java
@@ -122,9 +122,9 @@ class ImageStreamPresenter implements ImageStreamMvp.Presenter {
                 new InternalPermissionCallback() {
                     @Override
                     public void result(Map<String, Boolean> permissionResult) {
-                        for (Entry<String, Boolean> per : permissionResult.entrySet()) {
-                            if (Objects.equals(per.getKey(), permission.READ_MEDIA_AUDIO)
-                                    && per.getValue()) {
+                        for (Entry<String, Boolean> entryPermission : permissionResult.entrySet()) {
+                            if (Objects.equals(entryPermission.getKey(), permission.READ_MEDIA_AUDIO)
+                                    && entryPermission.getValue()) {
                                 ImageStreamPresenter.this.view.openMediaIntent(model.getDocumentIntent(),
                                         imageStreamBackend);
                             } else {

--- a/belvedere/src/main/java/zendesk/belvedere/ImageStreamPresenter.java
+++ b/belvedere/src/main/java/zendesk/belvedere/ImageStreamPresenter.java
@@ -1,11 +1,23 @@
 package zendesk.belvedere;
 
 
+import static zendesk.belvedere.BelvedereUi.FIVE_SECONDS_DELAY;
+import android.Manifest.permission;
+import android.app.Activity;
+import android.os.Build;
+import android.os.Build.VERSION_CODES;
 import android.view.View;
-
+import android.view.View.OnClickListener;
+import android.view.ViewGroup;
+import androidx.annotation.RequiresApi;
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import zendesk.belvedere.PermissionManager.InternalPermissionCallback;
 import zendesk.belvedere.ui.R;
 
 class ImageStreamPresenter implements ImageStreamMvp.Presenter {
@@ -77,16 +89,68 @@ class ImageStreamPresenter implements ImageStreamMvp.Presenter {
             view.showGooglePhotosMenuItem(clickListener);
         }
 
-        if(model.hasDocumentIntent()) {
-            final View.OnClickListener clickListener = new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    ImageStreamPresenter.this.view.openMediaIntent(model.getDocumentIntent(), imageStreamBackend);
-                }
-            };
-
-            view.showDocumentMenuItem(clickListener);
+        if (model.hasDocumentIntent()) {
+            openMediaFileScreen();
         }
+    }
+
+    /**
+     * Opens the media files screen.
+     */
+    private void openMediaFileScreen() {
+        final View.OnClickListener clickListener = new View.OnClickListener() {
+            @Override
+            public void onClick(final View view) {
+                if (Build.VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+                    openMediaOnPermissionGranted();
+                } else {
+                    ImageStreamPresenter.this.view.openMediaIntent(model.getDocumentIntent(),
+                            imageStreamBackend);
+                }
+            }
+        };
+        view.showDocumentMenuItem(clickListener);
+    }
+
+    /**
+     * Requests music and audio permission when the user tries to open the media files screen.
+     * It's only invoked on Android 13 and above.
+     */
+    @RequiresApi(api = 33)
+    private void openMediaOnPermissionGranted() {
+        imageStreamBackend.requestPermissions(Arrays.asList(permission.READ_MEDIA_AUDIO),
+                new InternalPermissionCallback() {
+                    @Override
+                    public void result(Map<String, Boolean> permissionResult) {
+                        for (Entry<String, Boolean> per : permissionResult.entrySet()) {
+                            if (Objects.equals(per.getKey(), permission.READ_MEDIA_AUDIO)
+                                    && per.getValue()) {
+                                ImageStreamPresenter.this.view.openMediaIntent(model.getDocumentIntent(),
+                                        imageStreamBackend);
+                            } else {
+                                displayBottomSheetDialogOnPermissionDenied();
+                            }
+                        }
+                    }
+                });
+    }
+
+    /**
+     * Displays the bottom sheet UI component when the user doesn't allow a required permission.
+     */
+    private void displayBottomSheetDialogOnPermissionDenied() {
+        final ViewGroup parentView = imageStreamBackend.getActivity().findViewById(android.R.id.content);
+        Utils.showBottomSheetDialog(
+                parentView,
+                imageStreamBackend.getString(R.string.belvedere_permissions_rationale),
+                FIVE_SECONDS_DELAY,
+                imageStreamBackend.getString(R.string.belvedere_navigate_to_settings),
+                new OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        Utils.openAppSettingsScreen(new WeakReference<>((Activity) imageStreamBackend.getActivity()));
+                    }
+                });
     }
 
     private void presentStream() {

--- a/belvedere/src/main/java/zendesk/belvedere/PermissionManager.java
+++ b/belvedere/src/main/java/zendesk/belvedere/PermissionManager.java
@@ -1,24 +1,38 @@
 package zendesk.belvedere;
 
+import static zendesk.belvedere.PermissionUtil.isPermissionGranted;
+
 import android.Manifest;
+import android.Manifest.permission;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.os.Build.VERSION_CODES;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 import androidx.fragment.app.Fragment;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 
 class PermissionManager {
 
     private static final int PERMISSION_REQUEST_CODE = 9842;
 
     private InternalPermissionCallback permissionListener = null;
+
+    @RequiresApi(api = 33)
+    private static final String[] TIRAMISU_PERMISSIONS = {
+            permission.READ_MEDIA_IMAGES,
+            permission.READ_MEDIA_VIDEO,
+            permission.READ_MEDIA_AUDIO
+    };
 
     boolean onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         if (requestCode == PERMISSION_REQUEST_CODE) {
@@ -120,22 +134,24 @@ class PermissionManager {
 
         final boolean canShowImageStream = canShowImageStream(context);
 
-        if(!canShowImageStream) {
-            permissions.add(Manifest.permission.READ_EXTERNAL_STORAGE);
+        if (!canShowImageStream) {
+            if (Build.VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+                Collections.addAll(permissions, TIRAMISU_PERMISSIONS);
+            } else {
+                permissions.add(Manifest.permission.READ_EXTERNAL_STORAGE);
+            }
         }
-
         return permissions;
     }
 
     private boolean canShowImageStream(Context context) {
         final boolean isBelowKitkat = Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT;
-        final boolean hasReadPermission = isPermissionGranted(context, Manifest.permission.READ_EXTERNAL_STORAGE);
+        final boolean hasReadPermission =
+                (Build.VERSION.SDK_INT >= VERSION_CODES.TIRAMISU)
+                        ? isPermissionGranted(context, TIRAMISU_PERMISSIONS)
+                        : isPermissionGranted(context, Manifest.permission.READ_EXTERNAL_STORAGE);
 
         return isBelowKitkat || hasReadPermission;
-    }
-
-    private boolean isPermissionGranted(Context context, String permission) {
-        return PermissionUtil.isPermissionGranted(context, permission);
     }
 
     private void setListener(InternalPermissionCallback listener) {

--- a/belvedere/src/main/java/zendesk/belvedere/PermissionManager.java
+++ b/belvedere/src/main/java/zendesk/belvedere/PermissionManager.java
@@ -31,7 +31,6 @@ class PermissionManager {
     private static final String[] TIRAMISU_PERMISSIONS = {
             permission.READ_MEDIA_IMAGES,
             permission.READ_MEDIA_VIDEO,
-            permission.READ_MEDIA_AUDIO
     };
 
     boolean onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
@@ -86,7 +85,7 @@ class PermissionManager {
         }
     }
 
-    private void askForPermissions(Fragment fragment, final List<String> permissions, final InternalPermissionCallback permissionCallback) {
+    public void askForPermissions(Fragment fragment, final List<String> permissions, final InternalPermissionCallback permissionCallback) {
         setListener(new InternalPermissionCallback() {
             @Override
             public void result(Map<String, Boolean> permissionResult) {
@@ -163,7 +162,7 @@ class PermissionManager {
         void onPermissionsDenied();
     }
 
-    private interface InternalPermissionCallback {
+    public interface InternalPermissionCallback {
         void result(Map<String, Boolean> permissionResult);
     }
 

--- a/belvedere/src/main/java/zendesk/belvedere/Utils.java
+++ b/belvedere/src/main/java/zendesk/belvedere/Utils.java
@@ -1,9 +1,13 @@
 package zendesk.belvedere;
 
+import static zendesk.belvedere.BelvedereUi.INTENT_URI_SCHEMA;
+
+import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnCancelListener;
 import android.content.DialogInterface.OnDismissListener;
+import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
@@ -14,7 +18,9 @@ import android.graphics.Paint;
 import android.graphics.RectF;
 import android.graphics.Shader;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.os.Handler;
+import android.provider.Settings;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -24,6 +30,7 @@ import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.squareup.picasso.Transformation;
+import java.lang.ref.WeakReference;
 import java.util.Locale;
 import zendesk.belvedere.ui.R;
 
@@ -84,6 +91,19 @@ class Utils {
         });
         bottomSheetDialog.show();
         handler.postDelayed(runnable, length);
+    }
+
+    static void openAppSettingsScreen(WeakReference<Activity> activity) {
+        Intent settingsIntent = new Intent();
+        settingsIntent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+        settingsIntent.setData(
+                Uri.fromParts(
+                        INTENT_URI_SCHEMA,
+                        activity.get().getPackageName(),
+                        null
+                )
+        );
+        activity.get().startActivity(settingsIntent);
     }
 
     static int getThemeColor(Context context, int attr) {

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ apply from: 'scripts/gradle/gradle-commons.gradle'
 apply from: 'scripts/gradle/zendesk-repos.gradle'
 
 ext {
-    compileSdkVersion = 30
-    targetSdkVersion = 30
+    compileSdkVersion = 33
+    targetSdkVersion = 33
     minSdkVersionCore = 16
     minSdkVersionUi = 16
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
     materialVersion = "1.2.0"
     gridLayoutVersion = "1.0.0"
     picassoVersion = "2.8"
-    versionName = "3.0.5-SNAPSHOT"
+    versionName = "3.0.5"
 
     buildSettings = [
             localBuild : true,


### PR DESCRIPTION
### Changes
This PR's changes allows supporting Android 13 version (API 33), which brings new runtime permissions that are required to access media files, where we have to request them individually ( Images, Video, Audio ) as known as granular permissions. 

# Allowing permission flow:

https://user-images.githubusercontent.com/85873565/181457089-a7373904-3011-4292-8289-3f870e6d2de9.mp4

# Denying music and audio permission flow:

https://user-images.githubusercontent.com/85873565/181457877-72d63b13-6208-4111-9a36-590bb7d19d1e.mp4

### References
- [Jira](https://zendesk.atlassian.net/browse/MFD-6389)

### Risks
- Low
