### PR TITLE
Bumping Snapshot Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
     materialVersion = "1.2.0"
     gridLayoutVersion = "1.0.0"
     picassoVersion = "2.8"
-    versionName = "3.0.5"
+    versionName = "3.0.6-SNAPSHOT"
 
     buildSettings = [
             localBuild : true,


### PR DESCRIPTION
### Changes
Bumping snapshot version from **3.0.5-SNAPSHOT** to **3.0.6-SNAPSHOT**

### References
- None

### Risks
- None
